### PR TITLE
Update Pervasives.compare to Stdlib.compare

### DIFF
--- a/src/file.ml
+++ b/src/file.ml
@@ -123,7 +123,7 @@ struct
     | Help_page
     | Replacement_text
 
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end
 
 type choice_kind =

--- a/src/state.ml
+++ b/src/state.ml
@@ -10,7 +10,7 @@ struct
     | List_choice
     | Help
 
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
 end
 
 module Context_map = Map.Make (Context)

--- a/termlib/key.ml
+++ b/termlib/key.ml
@@ -1535,7 +1535,7 @@ module Ordered =
 struct
   type key = t
   type t = key
-  let compare = (Pervasives.compare: t -> t -> int)
+  let compare = (Stdlib.compare: t -> t -> int)
 end
 
 module Set = Set.Make (Ordered)

--- a/termlib/spawn.ml
+++ b/termlib/spawn.ml
@@ -1,7 +1,7 @@
 module File_descr =
 struct
   type t = Unix.file_descr
-  let compare = (Pervasives.compare: Unix.file_descr -> Unix.file_descr -> int)
+  let compare = (Stdlib.compare: Unix.file_descr -> Unix.file_descr -> int)
 end
 
 module File_descr_map =


### PR DESCRIPTION
Pervasives has been renamed sometime before OCaml 5.2.0, the most recent version that I have in a switch.

Here's the error without this patch applied.

```
sh:2 $ make
ocamlbuild -no-links -use-ocamlfind -I termlib src/main.native
+ ocamlfind ocamlc -c -g -annot -w -23 -w -40 -package unix -I termlib -o termlib/key.cmo termlib/key.ml
File "termlib/key.ml", line 1538, characters 17-35:
1538 |   let compare = (Pervasives.compare: t -> t -> int)
                        ^^^^^^^^^^^^^^^^^^
Error: Unbound module "Pervasives"
Command exited with code 2.
Compilation unsuccessful after building 21 targets (18 cached) in 00:00:00.
make: *** [Makefile:12: red] Error 10
  2
```

Here's the warning you get with OCaml 4.13.1, which explains how to fix the problem.

```
+ ocamlfind ocamlc -c -g -annot -w -23 -w -40 -package unix -I src -I termlib -o src/file.cmo src/file.ml
File "src/file.ml", line 126, characters 16-34:
126 |   let compare = Pervasives.compare
                      ^^^^^^^^^^^^^^^^^^
Alert deprecated: module Stdlib.Pervasives
Use Stdlib instead.
```